### PR TITLE
Add Adyen connection example site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Adyen Connection Example
+
+This project demonstrates a simple setup for connecting an Adyen account using a static site and a minimal Node HTTP server.
+
+## Setup
+
+1. Replace `YOUR_ADYEN_CLIENT_KEY` in `index.html` with your real Adyen client key.
+2. Implement the API calls in `server.js` for `/api/paymentMethods` and `/api/makePayment` using your Adyen API credentials.
+3. Start the server:
+   ```bash
+   node server.js
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+This is only a basic example to get you started. You will need to implement additional error handling and security for production use.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Adyen Payment Example</title>
+  <script src="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/5.47.0/adyen.js"></script>
+  <link rel="stylesheet" href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/5.47.0/adyen.css" />
+</head>
+<body>
+  <div id="dropin-container"></div>
+  <script>
+    async function initAdyen() {
+      const configuration = {
+        clientKey: 'YOUR_ADYEN_CLIENT_KEY',
+        environment: 'test',
+        paymentMethodsResponse: await fetch('/api/paymentMethods').then(res => res.json()),
+        onSubmit: async (state, dropin) => {
+          const res = await fetch('/api/makePayment', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(state.data)
+          }).then(r => r.json());
+          if (res.action) {
+            dropin.handleAction(res.action);
+          } else if (res.resultCode) {
+            alert('Result: ' + res.resultCode);
+          }
+        }
+      };
+      const checkout = await AdyenCheckout(configuration);
+      checkout.create('dropin').mount('#dropin-container');
+    }
+    initAdyen();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rgm1995",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+    fs.createReadStream(path.join(__dirname, 'index.html')).pipe(res);
+  } else if (req.url.startsWith('/api/paymentMethods')) {
+    // TODO: implement call to Adyen paymentMethods API
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({}));
+  } else if (req.url.startsWith('/api/makePayment')) {
+    // TODO: implement call to Adyen payments API
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({ resultCode: 'Authorised' }));
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add example static site with Adyen drop‑in component
- add minimal Node HTTP server
- add README with setup instructions

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_687cc54c1420832ba42687b01e4ecdef